### PR TITLE
fix storybook failure

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -8,6 +8,7 @@ const { resolve } = require('path');
  * and if so, generate additional config options that will get merged into the storybook config
  * in order to process Typescript components and SCSS files appropriately.
  */
+
 const webpackConfig = require('../webpack.config');
 
 module.exports = {
@@ -39,4 +40,5 @@ module.exports = {
     '@storybook/addon-postcss',
     './register',
   ],
+  webpackFinal: webpackConfig
 };

--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -39,6 +39,6 @@ module.exports = {
     'storybook-addon-mdx-embed',
     '@storybook/addon-postcss',
     './register',
+    '@storybook/preset-scss'
   ],
-  webpackFinal: webpackConfig
 };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -83,6 +83,8 @@
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-postcss": "^2.0.0",
     "@storybook/addons": "^6.5.16",
+    "@storybook/instrumenter": "6.4.0",
+    "@storybook/preset-scss": "^1.0.3",
     "@storybook/react": "^6.5.16",
     "@storybook/storybook-deployer": "^2.8.16",
     "@storybook/testing-library": "^0.0.9",

--- a/packages/components/webpack.config.js
+++ b/packages/components/webpack.config.js
@@ -15,24 +15,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 const rules = [];
 
-// Process all SCSS modules which will be compiled inside the main JS bundle.
-const injectCssModulesInJS = {
-  test: /\.scss$/,
-  use: [
-    'style-loader',
-    {
-      loader: 'css-loader',
-      options: {
-        modules: {
-          localIdentName: '[local]__[hash:base64:5]',
-        },
-        sourceMap: true,
-      },
-    },
-    'sass-loader',
-    'postcss-loader',
-  ],
-};
 
 // Process all SCSS modules which will be compiled to an index.css
 const extractCssModulesToCss = {
@@ -77,17 +59,6 @@ const processFonts = {
     },
   ],
 };
-
-// When previewing or building storybook, global CSS is imported
-// via the storybook preview.js, so only modules need to be processed.
-// NOTE: this rule is merged with the rest of the storybook webpack config in
-// .storybook/main.js
-if (process.env.IS_STORYBOOK) {
-  rules.push(
-    { ...injectCssModulesInJS },
-    { ...processFonts },
-  );
-}
 
 // Rules for package publishing.
 // All JS is built with dts/rollup but

--- a/packages/components/webpack.config.js
+++ b/packages/components/webpack.config.js
@@ -32,7 +32,6 @@ const injectCssModulesInJS = {
     'sass-loader',
     'postcss-loader',
   ],
-  include: /\.module\.scss$/,
 };
 
 // Process all SCSS modules which will be compiled to an index.css
@@ -86,6 +85,7 @@ const processFonts = {
 if (process.env.IS_STORYBOOK) {
   rules.push(
     { ...injectCssModulesInJS },
+    { ...processFonts },
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,12 @@ importers:
       '@storybook/addons':
         specifier: ^6.5.16
         version: 6.5.16(react-dom@16.14.0)(react@16.14.0)
+      '@storybook/instrumenter':
+        specifier: 6.4.0
+        version: 6.4.0(react-dom@16.14.0)(react@16.14.0)
+      '@storybook/preset-scss':
+        specifier: ^1.0.3
+        version: 1.0.3(css-loader@3.6.0)(sass-loader@8.0.2)(style-loader@1.3.0)
       '@storybook/react':
         specifier: ^6.5.16
         version: 6.5.16(@babel/core@7.23.9)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(require-from-string@2.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)(webpack-dev-server@3.11.3)
@@ -122,7 +128,7 @@ importers:
         version: 2.8.16
       '@storybook/testing-library':
         specifier: ^0.0.9
-        version: 0.0.9
+        version: 0.0.9(react-dom@16.14.0)(react@16.14.0)
       '@storybook/testing-react':
         specifier: ^1.3.0
         version: 1.3.0(@storybook/addons@6.5.16)(@storybook/client-api@7.6.16)(@storybook/preview-web@7.6.16)(@storybook/react@6.5.16)(react@16.14.0)
@@ -3267,7 +3273,6 @@ packages:
       '@emotion/stylis': 0.8.5
       '@emotion/utils': 0.11.3
       '@emotion/weak-memoize': 0.2.5
-    dev: false
 
   /@emotion/core@10.3.1(react@16.14.0):
     resolution: {integrity: sha512-447aUEjPIm0MnE6QYIaFz9VQOHSXf4Iu6EWOIqq11EAPqinkSZmfymPTmlOE3QjLv846lH4JVZBUOtwGbuQoww==}
@@ -3281,7 +3286,6 @@ packages:
       '@emotion/sheet': 0.9.4
       '@emotion/utils': 0.11.3
       react: 16.14.0
-    dev: false
 
   /@emotion/css@10.0.27:
     resolution: {integrity: sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==}
@@ -3289,15 +3293,18 @@ packages:
       '@emotion/serialize': 0.11.16
       '@emotion/utils': 0.11.3
       babel-plugin-emotion: 10.2.2
-    dev: false
 
   /@emotion/hash@0.8.0:
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
-    dev: false
+
+  /@emotion/is-prop-valid@0.8.8:
+    resolution: {integrity: sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==}
+    dependencies:
+      '@emotion/memoize': 0.7.4
+    dev: true
 
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
-    dev: false
 
   /@emotion/serialize@0.11.16:
     resolution: {integrity: sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==}
@@ -3307,27 +3314,47 @@ packages:
       '@emotion/unitless': 0.7.5
       '@emotion/utils': 0.11.3
       csstype: 2.6.21
-    dev: false
 
   /@emotion/sheet@0.9.4:
     resolution: {integrity: sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==}
-    dev: false
+
+  /@emotion/styled-base@10.3.0(@emotion/core@10.3.1)(react@16.14.0):
+    resolution: {integrity: sha512-PBRqsVKR7QRNkmfH78hTSSwHWcwDpecH9W6heujWAcyp2wdz/64PP73s7fWS1dIPm8/Exc8JAzYS8dEWXjv60w==}
+    peerDependencies:
+      '@emotion/core': ^10.0.28
+      react: '>=16.3.0'
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@emotion/core': 10.3.1(react@16.14.0)
+      '@emotion/is-prop-valid': 0.8.8
+      '@emotion/serialize': 0.11.16
+      '@emotion/utils': 0.11.3
+      react: 16.14.0
+    dev: true
+
+  /@emotion/styled@10.3.0(@emotion/core@10.3.1)(react@16.14.0):
+    resolution: {integrity: sha512-GgcUpXBBEU5ido+/p/mCT2/Xx+Oqmp9JzQRuC+a4lYM4i4LBBn/dWvc0rQ19N9ObA8/T4NWMrPNe79kMBDJqoQ==}
+    peerDependencies:
+      '@emotion/core': ^10.0.27
+      react: '>=16.3.0'
+    dependencies:
+      '@emotion/core': 10.3.1(react@16.14.0)
+      '@emotion/styled-base': 10.3.0(@emotion/core@10.3.1)(react@16.14.0)
+      babel-plugin-emotion: 10.2.2
+      react: 16.14.0
+    dev: true
 
   /@emotion/stylis@0.8.5:
     resolution: {integrity: sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==}
-    dev: false
 
   /@emotion/unitless@0.7.5:
     resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
-    dev: false
 
   /@emotion/utils@0.11.3:
     resolution: {integrity: sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==}
-    dev: false
 
   /@emotion/weak-memoize@0.2.5:
     resolution: {integrity: sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==}
-    dev: false
 
   /@eslint-community/eslint-utils@4.4.0(eslint@7.32.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -3727,13 +3754,6 @@ packages:
       v8-to-istanbul: 8.1.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@jest/schemas@29.6.3:
-    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@sinclair/typebox': 0.27.8
     dev: true
 
   /@jest/source-map@26.6.2:
@@ -4313,6 +4333,11 @@ packages:
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
+  /@remix-run/router@1.15.1:
+    resolution: {integrity: sha512-zcU0gM3z+3iqj8UX45AmWY810l3oUmXM7uH4dt5xtzvMhRtYVhKGOmgOd1877dOPPepfCjUv57w+syamWIYe7w==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /@rollup/plugin-babel@5.3.1(@babel/core@7.23.9)(rollup@2.79.1):
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
@@ -4640,10 +4665,6 @@ packages:
       semantic-release: 22.0.12
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@sinclair/typebox@0.27.8:
-    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
   /@sindresorhus/is@4.6.0:
@@ -5105,6 +5126,27 @@ packages:
       regenerator-runtime: 0.13.11
     dev: true
 
+  /@storybook/addons@6.4.0(react-dom@16.14.0)(react@16.14.0):
+    resolution: {integrity: sha512-57IaMaG3FBK+SC8k/6i1GvLUFtNGfSISEMTJUd5qZszXj0Y5NhhBOTgz0Bb5l4zJJ6kHwP0eCcWi0ulV7nVsqw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@storybook/api': 6.4.0(react-dom@16.14.0)(react@16.14.0)
+      '@storybook/channels': 6.4.0
+      '@storybook/client-logger': 6.4.0
+      '@storybook/core-events': 6.4.0
+      '@storybook/csf': 0.0.2--canary.87bc651.0
+      '@storybook/router': 6.4.0(react-dom@16.14.0)(react@16.14.0)
+      '@storybook/theming': 6.4.0(react-dom@16.14.0)(react@16.14.0)
+      '@types/webpack-env': 1.18.4
+      core-js: 3.36.0
+      global: 4.4.0
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      regenerator-runtime: 0.13.11
+    dev: true
+
   /@storybook/addons@6.5.16(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-p3DqQi+8QRL5k7jXhXmJZLsE/GqHqyY6PcoA1oNTJr0try48uhTGUOYkgzmqtDaa/qPFO5LP+xCPzZXckGtquQ==}
     peerDependencies:
@@ -5124,6 +5166,33 @@ packages:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)
       regenerator-runtime: 0.13.11
+    dev: true
+
+  /@storybook/api@6.4.0(react-dom@16.14.0)(react@16.14.0):
+    resolution: {integrity: sha512-7/+eHMsQOf0DoQWR7FVYRzLK2JoG+q5RytW9AgpTOJXELONC9/ewKSQdN3X6/WxNc+a9ycxWvTJPPR5m5jMb3A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@storybook/channels': 6.4.0
+      '@storybook/client-logger': 6.4.0
+      '@storybook/core-events': 6.4.0
+      '@storybook/csf': 0.0.2--canary.87bc651.0
+      '@storybook/router': 6.4.0(react-dom@16.14.0)(react@16.14.0)
+      '@storybook/semver': 7.3.2
+      '@storybook/theming': 6.4.0(react-dom@16.14.0)(react@16.14.0)
+      core-js: 3.36.0
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      regenerator-runtime: 0.13.11
+      store2: 2.14.3
+      telejson: 5.3.3
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
     dev: true
 
   /@storybook/api@6.5.16(react-dom@16.14.0)(react@16.14.0):
@@ -5244,6 +5313,14 @@ packages:
       telejson: 6.0.8
     dev: true
 
+  /@storybook/channels@6.4.0:
+    resolution: {integrity: sha512-wJMQnR6YoDzU30Nb2ow4CveG5uatJOQIsNm+ZZYluJuYPqNc+aZCQWXT0yjx5/iYlfZAB0Bv8sLm9nc2p3dzeA==}
+    dependencies:
+      core-js: 3.36.0
+      ts-dedent: 2.2.0
+      util-deprecate: 1.0.2
+    dev: true
+
   /@storybook/channels@6.5.16:
     resolution: {integrity: sha512-VylzaWQZaMozEwZPJdyJoz+0jpDa8GRyaqu9TGG6QGv+KU5POoZaGLDkRE7TzWkyyP0KQLo80K99MssZCpgSeg==}
     dependencies:
@@ -5298,6 +5375,13 @@ packages:
     dependencies:
       '@storybook/client-logger': 7.6.16
       '@storybook/preview-api': 7.6.16
+    dev: true
+
+  /@storybook/client-logger@6.4.0:
+    resolution: {integrity: sha512-SFO/JhQeoXl57LMwCp0HsxkgDjU2TLv+7S7s8UJI3nmdAcrPBhJ+RAwI8IoB/AozQMvSVb2fPiV1ljoSfSZLAg==}
+    dependencies:
+      core-js: 3.36.0
+      global: 4.4.0
     dev: true
 
   /@storybook/client-logger@6.5.16:
@@ -5437,6 +5521,12 @@ packages:
       - vue-template-compiler
       - webpack-cli
       - webpack-command
+    dev: true
+
+  /@storybook/core-events@6.4.0:
+    resolution: {integrity: sha512-uOwLYt95J6U5BUgw/e9KGRw1jBq6vyoLUG4GZbPc7a9DLmES31zpqpKaFPAUoYel/TPUHgTLlKRIg8uyjv9vLg==}
+    dependencies:
+      core-js: 3.36.0
     dev: true
 
   /@storybook/core-events@6.5.16:
@@ -5628,16 +5718,16 @@ packages:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
     dev: true
 
-  /@storybook/instrumenter@7.6.16:
-    resolution: {integrity: sha512-b/X34w08yhWxN+hFjjO09LP9ubwVLOPaF1P2uvOfzbnhv7E5xNsbCG3Czk00Rx8OUeeU97Q0ZArUjOAj3HFNcQ==}
+  /@storybook/instrumenter@6.4.0(react-dom@16.14.0)(react@16.14.0):
+    resolution: {integrity: sha512-QaDJH6AJUeslxIgUzyZg9gTrwfFVCbRLpj/tnsot7ph/dt7/7JPOhbb7xyeJ9iFxoYKYJ8OR0hzIpuzhQxrVrQ==}
     dependencies:
-      '@storybook/channels': 7.6.16
-      '@storybook/client-logger': 7.6.16
-      '@storybook/core-events': 7.6.16
-      '@storybook/global': 5.0.0
-      '@storybook/preview-api': 7.6.16
-      '@vitest/utils': 0.34.7
-      util: 0.12.5
+      '@storybook/addons': 6.4.0(react-dom@16.14.0)(react@16.14.0)
+      '@storybook/client-logger': 6.4.0
+      '@storybook/core-events': 6.4.0
+      global: 4.4.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
     dev: true
 
   /@storybook/manager-webpack4@6.5.16(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(typescript@4.9.5)(webpack-cli@3.3.12):
@@ -5731,6 +5821,18 @@ packages:
     resolution: {integrity: sha512-08K2q+qN6pqyPW7PHLCZ5G5Xa6Wosd6t0F16PQ4abX2ItlJLabVoJN5mZ0gm/aeLTjD8QYr8IDvacu4eXh0SVA==}
     dependencies:
       core-js: 3.36.0
+    dev: true
+
+  /@storybook/preset-scss@1.0.3(css-loader@3.6.0)(sass-loader@8.0.2)(style-loader@1.3.0):
+    resolution: {integrity: sha512-o9Iz6wxPeNENrQa2mKlsDKynBfqU2uWaRP80HeWp4TkGgf7/x3DVF2O7yi9N0x/PI1qzzTTpxlQ90D62XmpiTw==}
+    peerDependencies:
+      css-loader: '*'
+      sass-loader: '*'
+      style-loader: '*'
+    dependencies:
+      css-loader: 3.6.0(webpack@4.47.0)
+      sass-loader: 8.0.2(sass@1.71.0)(webpack@4.47.0)
+      style-loader: 1.3.0(webpack@4.47.0)
     dev: true
 
   /@storybook/preview-api@7.6.16:
@@ -5891,6 +5993,27 @@ packages:
       - webpack-plugin-serve
     dev: true
 
+  /@storybook/router@6.4.0(react-dom@16.14.0)(react@16.14.0):
+    resolution: {integrity: sha512-qd6GisJUIf/8fjrTlzIg5MfXLm2b2u33PiHYknm9Pu2wu4FOj8A4jfwKccy9tQ1w8GcEysjF4YQseIG1RK0VTw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@storybook/client-logger': 6.4.0
+      core-js: 3.36.0
+      fast-deep-equal: 3.1.3
+      global: 4.4.0
+      history: 5.0.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+      qs: 6.11.2
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      react-router: 6.22.1(react@16.14.0)
+      react-router-dom: 6.22.1(react-dom@16.14.0)(react@16.14.0)
+      ts-dedent: 2.2.0
+    dev: true
+
   /@storybook/router@6.5.16(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-ZgeP8a5YV/iuKbv31V8DjPxlV4AzorRiR8OuSt/KqaiYXNXlOoQDz/qMmiNcrshrfLpmkzoq7fSo4T8lWo2UwQ==}
     peerDependencies:
@@ -5998,14 +6121,17 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/testing-library@0.0.9:
+  /@storybook/testing-library@0.0.9(react-dom@16.14.0)(react@16.14.0):
     resolution: {integrity: sha512-X4/Tk7RryB0tZ/9NLUHYTBXW01zRpf6+IhdhqsVl6WOWRyUaIv3zEhr43gQyZhBe4ZZyt5d90FJC9qWmY1oFKg==}
     dependencies:
       '@storybook/client-logger': 7.6.16
-      '@storybook/instrumenter': 7.6.16
+      '@storybook/instrumenter': 6.4.0(react-dom@16.14.0)(react@16.14.0)
       '@testing-library/dom': 8.20.1
       '@testing-library/user-event': 13.5.0(@testing-library/dom@8.20.1)
       ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - react
+      - react-dom
     dev: true
 
   /@storybook/testing-react@1.3.0(@storybook/addons@6.5.16)(@storybook/client-api@7.6.16)(@storybook/preview-web@7.6.16)(@storybook/react@6.5.16)(react@16.14.0):
@@ -6024,6 +6150,28 @@ packages:
       '@storybook/preview-web': 7.6.16
       '@storybook/react': 6.5.16(@babel/core@7.23.9)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(require-from-string@2.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)(webpack-dev-server@3.11.3)
       react: 16.14.0
+    dev: true
+
+  /@storybook/theming@6.4.0(react-dom@16.14.0)(react@16.14.0):
+    resolution: {integrity: sha512-h07H/crnt7IpgYm0fXiFRtvLgcxjyCRi9+QjXK+aroYjWQYFkSKh1Z8jrGsXGZ42059hPyE9GvpzbJGMVlAELA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@emotion/core': 10.3.1(react@16.14.0)
+      '@emotion/is-prop-valid': 0.8.8
+      '@emotion/styled': 10.3.0(@emotion/core@10.3.1)(react@16.14.0)
+      '@storybook/client-logger': 6.4.0
+      core-js: 3.36.0
+      deep-object-diff: 1.1.9
+      emotion-theming: 10.3.0(@emotion/core@10.3.1)(react@16.14.0)
+      global: 4.4.0
+      memoizerific: 1.11.3
+      polished: 4.3.1
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      resolve-from: 5.0.0
+      ts-dedent: 2.2.0
     dev: true
 
   /@storybook/theming@6.5.16(react-dom@16.14.0)(react@16.14.0):
@@ -6982,14 +7130,6 @@ packages:
 
   /@ungap/structured-clone@1.2.0:
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
-    dev: true
-
-  /@vitest/utils@0.34.7:
-    resolution: {integrity: sha512-ziAavQLpCYS9sLOorGrFFKmy2gnfiNU0ZJ15TsMz/K92NAPS/rp9K4z6AJQQk5Y8adCy4Iwpxy7pQumQ/psnRg==}
-    dependencies:
-      diff-sequences: 29.6.3
-      loupe: 2.3.7
-      pretty-format: 29.7.0
     dev: true
 
   /@webassemblyjs/ast@1.9.0:
@@ -8049,7 +8189,6 @@ packages:
       escape-string-regexp: 1.0.5
       find-root: 1.1.0
       source-map: 0.5.7
-    dev: false
 
   /babel-plugin-extract-import-names@1.6.22:
     resolution: {integrity: sha512-yJ9BsJaISua7d8zNT7oRG1ZLBJCIdZ4PZqmH8qa9N5AK01ifk3fnkc98AXhtzE7UkfCsEumvoQWgoYLhOnJ7jQ==}
@@ -8185,7 +8324,6 @@ packages:
 
   /babel-plugin-syntax-jsx@6.18.0:
     resolution: {integrity: sha512-qrPaCSo9c8RHNRHIotaufGbuOBN8rtdC4QrrFFc43vyWCCz7Kl7GL1PGaXtMGQZUXrkCjNEgxDfmAuAabr/rlw==}
-    dev: false
 
   /babel-plugin-syntax-trailing-function-commas@6.22.0:
     resolution: {integrity: sha512-Gx9CH3Q/3GKbhs07Bszw5fPTlU+ygrOGfAhEt7W2JICwufpC4SuO0mG0+4NykPBSYPMJhqvVlDBU17qB1D+hMQ==}
@@ -10441,7 +10579,6 @@ packages:
 
   /csstype@2.6.21:
     resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
-    dev: false
 
   /csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -10630,6 +10767,10 @@ packages:
 
   /deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+    dev: true
+
+  /deep-object-diff@1.1.9:
+    resolution: {integrity: sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA==}
     dev: true
 
   /deepmerge@2.2.1:
@@ -10842,11 +10983,6 @@ packages:
   /diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
-    dev: true
-
-  /diff-sequences@29.6.3:
-    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /diff@4.0.2:
@@ -11191,6 +11327,19 @@ packages:
   /emojis-list@3.0.0:
     resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
     engines: {node: '>= 4'}
+    dev: true
+
+  /emotion-theming@10.3.0(@emotion/core@10.3.1)(react@16.14.0):
+    resolution: {integrity: sha512-mXiD2Oj7N9b6+h/dC6oLf9hwxbtKHQjoIqtodEyL8CpkN4F3V4IK/BT4D0C7zSs4BBFOu4UlPJbvvBLa88SGEA==}
+    peerDependencies:
+      '@emotion/core': ^10.0.27
+      react: '>=16.3.0'
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@emotion/core': 10.3.1(react@16.14.0)
+      '@emotion/weak-memoize': 0.2.5
+      hoist-non-react-statics: 3.3.2
+      react: 16.14.0
     dev: true
 
   /encodeurl@1.0.2:
@@ -12589,7 +12738,6 @@ packages:
 
   /find-root@1.1.0:
     resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
-    dev: false
 
   /find-up-simple@1.0.0:
     resolution: {integrity: sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==}
@@ -12817,11 +12965,6 @@ packages:
       mime-types: 2.1.35
     dev: true
 
-  /format@0.2.2:
-    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
-    engines: {node: '>=0.4.x'}
-    dev: true
-
   /formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -13032,10 +13175,6 @@ packages:
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-    dev: true
-
-  /get-func-name@2.0.2:
-    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: true
 
   /get-intrinsic@1.2.4:
@@ -13683,6 +13822,12 @@ packages:
       tiny-invariant: 1.3.1
       tiny-warning: 1.0.3
       value-equal: 1.0.1
+    dev: true
+
+  /history@5.0.0:
+    resolution: {integrity: sha512-3NyRMKIiFSJmIPdq7FxkNMJkQ7ZEtVblOQ38VtKaA0zZMW1Eo6Q6W8oDKEflr1kNNTItSnk4JMCO1deeSgbLLg==}
+    dependencies:
+      '@babel/runtime': 7.23.9
     dev: true
 
   /hmac-drbg@1.0.1:
@@ -16407,12 +16552,6 @@ packages:
       signal-exit: 3.0.7
     dev: true
     optional: true
-
-  /loupe@2.3.7:
-    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
-    dependencies:
-      get-func-name: 2.0.2
-    dev: true
 
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -19235,15 +19374,6 @@ packages:
       react-is: 17.0.2
     dev: true
 
-  /pretty-format@29.7.0:
-    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/schemas': 29.6.3
-      ansi-styles: 5.2.0
-      react-is: 18.2.0
-    dev: true
-
   /pretty-hrtime@1.0.3:
     resolution: {integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==}
     engines: {node: '>= 0.8'}
@@ -19670,10 +19800,6 @@ packages:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
     dev: true
 
-  /react-is@18.2.0:
-    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
-    dev: true
-
   /react-merge-refs@1.1.0:
     resolution: {integrity: sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==}
     dev: false
@@ -19737,6 +19863,19 @@ packages:
       tiny-warning: 1.0.3
     dev: true
 
+  /react-router-dom@6.22.1(react-dom@16.14.0)(react@16.14.0):
+    resolution: {integrity: sha512-iwMyyyrbL7zkKY7MRjOVRy+TMnS/OPusaFVxM2P11x9dzSzGmLsebkCvYirGq0DWB9K9hOspHYYtDz33gE5Duw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.15.1
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      react-router: 6.22.1(react@16.14.0)
+    dev: true
+
   /react-router@5.3.4(react@16.14.0):
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
@@ -19752,6 +19891,16 @@ packages:
       react-is: 16.13.1
       tiny-invariant: 1.3.1
       tiny-warning: 1.0.3
+    dev: true
+
+  /react-router@6.22.1(react@16.14.0):
+    resolution: {integrity: sha512-0pdoRGwLtemnJqn1K0XHUbnKiX0S4X8CgvVVmHGOWmofESj31msHo/1YiqcJWK7Wxfq2a4uvvtS01KAQyWK/CQ==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      '@remix-run/router': 1.15.1
+      react: 16.14.0
     dev: true
 
   /react-select-event@4.2.0:
@@ -22152,6 +22301,19 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /telejson@5.3.3:
+    resolution: {integrity: sha512-PjqkJZpzEggA9TBpVtJi1LVptP7tYtXB6rEubwlHap76AMjzvOdKX41CxyaW7ahhzDU1aftXnMCx5kAPDZTQBA==}
+    dependencies:
+      '@types/is-function': 1.0.3
+      global: 4.4.0
+      is-function: 1.0.2
+      is-regex: 1.1.4
+      is-symbol: 1.0.4
+      isobject: 4.0.0
+      lodash: 4.17.21
+      memoizerific: 1.11.3
+    dev: true
+
   /telejson@6.0.8:
     resolution: {integrity: sha512-nerNXi+j8NK1QEfBHtZUN/aLdDcyupA//9kAboYLrtzZlPLpUfqbVGWb9zz91f/mIjRbAYhbgtnJHY8I1b5MBg==}
     dependencies:
@@ -23186,16 +23348,6 @@ packages:
     resolution: {integrity: sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==}
     dependencies:
       inherits: 2.0.3
-    dev: true
-
-  /util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.1.1
-      is-generator-function: 1.0.10
-      is-typed-array: 1.1.13
-      which-typed-array: 1.1.14
     dev: true
 
   /utila@0.4.0:


### PR DESCRIPTION
Fixes https://github.com/rhinolabs/rhino-ui/issues/1

There are two issues here.
1. The scss loader is not picked up by the storybook webpack compiler.
![image](https://github.com/rhinolabs/rhino-ui/assets/25629064/48cc8262-51ce-46c9-9c9c-59af474f88fc)

2. The package `@storybook/instrumenter` is built with .mjs (ES Modules) which is not resolved by the storybook webpack configuration.
![image](https://github.com/rhinolabs/rhino-ui/assets/25629064/e942d98c-b03d-4781-a2c7-7307dc3b13a3)

In order to fix these two issues we need to do the following.

1. Use the @storybook/preset-scss plugin which will automatically load the .scss files for us. (Not that the rules in the `webpack.config.js` file will not be automatically merged with the rules from storybook's webpack config.
2. Install a version of `@storybook/instrumenter` that uses commonjs modules. 



### Screenshot

![image](https://github.com/rhinolabs/rhino-ui/assets/25629064/f801c0e4-21a0-4dd5-a796-d72cd945da11)
