### PR TITLE
use custom sass loader rule

### DIFF
--- a/packages/components/.storybook/main.js
+++ b/packages/components/.storybook/main.js
@@ -38,7 +38,34 @@ module.exports = {
     'storybook-addon-designs',
     'storybook-addon-mdx-embed',
     '@storybook/addon-postcss',
-    './register',
-    '@storybook/preset-scss'
+    './register'
   ],
+  webpackFinal: async (config) => {
+    return {
+      ...config,
+      module: {
+        ...config.module,
+        rules: [
+          ...config.module.rules,
+          {
+            test: /\.scss$/,
+            use: [
+              'style-loader',
+              {
+                loader: 'css-loader',
+                options: {
+                  modules: {
+                    localIdentName: '[local]__[hash:base64:5]',
+                  },
+                  sourceMap: true,
+                },
+              },
+              'sass-loader',
+              'postcss-loader',
+            ]
+          }
+        ]
+      }
+    }
+  }
 };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -84,7 +84,6 @@
     "@storybook/addon-postcss": "^2.0.0",
     "@storybook/addons": "^6.5.16",
     "@storybook/instrumenter": "6.4.0",
-    "@storybook/preset-scss": "^1.0.3",
     "@storybook/react": "^6.5.16",
     "@storybook/storybook-deployer": "^2.8.16",
     "@storybook/testing-library": "^0.0.9",

--- a/packages/components/webpack.config.js
+++ b/packages/components/webpack.config.js
@@ -15,7 +15,6 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 
 const rules = [];
 
-
 // Process all SCSS modules which will be compiled to an index.css
 const extractCssModulesToCss = {
   test: /\.scss$/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,9 +117,6 @@ importers:
       '@storybook/instrumenter':
         specifier: 6.4.0
         version: 6.4.0(react-dom@16.14.0)(react@16.14.0)
-      '@storybook/preset-scss':
-        specifier: ^1.0.3
-        version: 1.0.3(css-loader@3.6.0)(sass-loader@8.0.2)(style-loader@1.3.0)
       '@storybook/react':
         specifier: ^6.5.16
         version: 6.5.16(@babel/core@7.23.9)(eslint@7.32.0)(react-dom@16.14.0)(react@16.14.0)(require-from-string@2.0.2)(typescript@4.9.5)(webpack-cli@3.3.12)(webpack-dev-server@3.11.3)
@@ -5821,18 +5818,6 @@ packages:
     resolution: {integrity: sha512-08K2q+qN6pqyPW7PHLCZ5G5Xa6Wosd6t0F16PQ4abX2ItlJLabVoJN5mZ0gm/aeLTjD8QYr8IDvacu4eXh0SVA==}
     dependencies:
       core-js: 3.36.0
-    dev: true
-
-  /@storybook/preset-scss@1.0.3(css-loader@3.6.0)(sass-loader@8.0.2)(style-loader@1.3.0):
-    resolution: {integrity: sha512-o9Iz6wxPeNENrQa2mKlsDKynBfqU2uWaRP80HeWp4TkGgf7/x3DVF2O7yi9N0x/PI1qzzTTpxlQ90D62XmpiTw==}
-    peerDependencies:
-      css-loader: '*'
-      sass-loader: '*'
-      style-loader: '*'
-    dependencies:
-      css-loader: 3.6.0(webpack@4.47.0)
-      sass-loader: 8.0.2(sass@1.71.0)(webpack@4.47.0)
-      style-loader: 1.3.0(webpack@4.47.0)
     dev: true
 
   /@storybook/preview-api@7.6.16:


### PR DESCRIPTION
Fixes the missing CSS by adding a custom rule to the storybook config.

## Screenshot

![image](https://github.com/rhinolabs/rhino-ui/assets/25629064/06b4b82d-3a60-4d19-8426-45bd2288371f)

