### PR TITLE
fix typescript annotations in storybook

### DIFF
--- a/packages/components/src/components/accordion/accordion.playground.stories.tsx
+++ b/packages/components/src/components/accordion/accordion.playground.stories.tsx
@@ -58,7 +58,7 @@ const Template: StoryFn<AccordionProps> = ({
   </Accordion>
 );
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<AccordionProps> = Template.bind({});
 
 Playground.args = {
   openPanels: [],

--- a/packages/components/src/components/alert/alert.playground.stories.tsx
+++ b/packages/components/src/components/alert/alert.playground.stories.tsx
@@ -41,7 +41,7 @@ export default meta;
 
 const Template: StoryFn<AlertProps> = ({ ...args }) => <Alert {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<AlertProps> = Template.bind({});
 Playground.args = {
   variant: 'default',
   message: 'default',

--- a/packages/components/src/components/alert/alert.visual-tests.stories.tsx
+++ b/packages/components/src/components/alert/alert.visual-tests.stories.tsx
@@ -37,7 +37,7 @@ const Template: StoryFn<AlertProps> = args => (
   </Box>
 );
 
-export const AllProps = Template.bind({});
+export const AllProps: StoryFn<AlertProps> = Template.bind({});
 AllProps.args = {
   title: 'Title Text',
   message: 'Message text',
@@ -45,12 +45,12 @@ AllProps.args = {
   isClosable: true,
 };
 
-export const TitleOnly = Template.bind({});
+export const TitleOnly: StoryFn<AlertProps> = Template.bind({});
 TitleOnly.args = {
   title: 'Title Text Only',
 };
 
-export const MessageOnly = Template.bind({});
+export const MessageOnly: StoryFn<AlertProps> = Template.bind({});
 MessageOnly.args = {
   message: 'Message text only',
 };

--- a/packages/components/src/components/badge/badge.playground.stories.tsx
+++ b/packages/components/src/components/badge/badge.playground.stories.tsx
@@ -36,7 +36,7 @@ const Template: StoryFn<BadgeProps> = ({ ...args }) => <Badge {...args} />;
  * Use the playground to see different results
  */
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<BadgeProps> = Template.bind({});
 Playground.args = {
   variant: 'primary',
   message: 'install ready',

--- a/packages/components/src/components/badge/badge.visual-tests.stories.tsx
+++ b/packages/components/src/components/badge/badge.visual-tests.stories.tsx
@@ -36,4 +36,4 @@ const Template: StoryFn<BadgeProps> = args => (
   </Box>
 );
 
-export const VariantsAndSizes = Template.bind({});
+export const VariantsAndSizes: StoryFn<BadgeProps> = Template.bind({});

--- a/packages/components/src/components/box/box.playground.stories.tsx
+++ b/packages/components/src/components/box/box.playground.stories.tsx
@@ -447,7 +447,7 @@ const Template: StoryFn<BoxProps> = ({
   );
 };
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<BoxProps> = Template.bind({});
 Playground.args = {
   background: 'info-300',
   direction: 'row',

--- a/packages/components/src/components/box/box.visual-tests.stories.tsx
+++ b/packages/components/src/components/box/box.visual-tests.stories.tsx
@@ -473,7 +473,7 @@ const BoxTemplate: StoryFn<BoxProps> = ({ propertyName, ...args }) => {
   );
 };
 
-export const ResponsiveFontSize = BoxTemplate.bind({});
+export const ResponsiveFontSize: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveFontSize.args = {
   propertyName: 'fontSize',
   fontSize: {
@@ -486,7 +486,7 @@ ResponsiveFontSize.args = {
 };
 ResponsiveFontSize.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveRadius = BoxTemplate.bind({});
+export const ResponsiveRadius: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveRadius.args = {
   propertyName: 'radius',
   radius: {
@@ -500,7 +500,7 @@ ResponsiveRadius.args = {
 };
 ResponsiveRadius.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveShadow = BoxTemplate.bind({});
+export const ResponsiveShadow: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveShadow.args = {
   propertyName: 'shadow',
   shadow: {
@@ -514,7 +514,7 @@ ResponsiveShadow.args = {
 };
 ResponsiveShadow.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveTextAlign = BoxTemplate.bind({});
+export const ResponsiveTextAlign: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveTextAlign.args = {
   propertyName: 'textAlign',
   textAlign: {
@@ -527,7 +527,7 @@ ResponsiveTextAlign.args = {
 };
 ResponsiveTextAlign.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveBorderWidth = BoxTemplate.bind({});
+export const ResponsiveBorderWidth: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveBorderWidth.args = {
   propertyName: 'borderWidth',
   borderWidth: {
@@ -541,7 +541,7 @@ ResponsiveBorderWidth.args = {
 };
 ResponsiveBorderWidth.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveWidth = BoxTemplate.bind({});
+export const ResponsiveWidth: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveWidth.args = {
   propertyName: 'width',
   width: {
@@ -556,7 +556,7 @@ ResponsiveWidth.args = {
 };
 ResponsiveWidth.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveMaxWidth = BoxTemplate.bind({});
+export const ResponsiveMaxWidth: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveMaxWidth.args = {
   propertyName: 'maxWidth',
   maxWidth: {
@@ -572,7 +572,7 @@ ResponsiveMaxWidth.args = {
 };
 ResponsiveMaxWidth.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveMinWidth = BoxTemplate.bind({});
+export const ResponsiveMinWidth: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveMinWidth.args = {
   propertyName: 'minWidth',
   minWidth: {
@@ -589,7 +589,7 @@ ResponsiveMinWidth.args = {
 };
 ResponsiveMinWidth.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveHeight = BoxTemplate.bind({});
+export const ResponsiveHeight: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveHeight.args = {
   propertyName: 'height',
   height: {
@@ -604,7 +604,7 @@ ResponsiveHeight.args = {
 };
 ResponsiveHeight.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveMaxHeight = BoxTemplate.bind({});
+export const ResponsiveMaxHeight: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveMaxHeight.args = {
   propertyName: 'maxHeight',
   maxHeight: {
@@ -620,7 +620,7 @@ ResponsiveMaxHeight.args = {
 };
 ResponsiveMaxHeight.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveMinHeight = BoxTemplate.bind({});
+export const ResponsiveMinHeight: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveMinHeight.args = {
   propertyName: 'minHeight',
   minHeight: {
@@ -636,7 +636,7 @@ ResponsiveMinHeight.args = {
 };
 ResponsiveMinHeight.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveMargin = BoxTemplate.bind({});
+export const ResponsiveMargin: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsiveMargin.args = {
   propertyName: 'margin',
   margin: {
@@ -650,7 +650,7 @@ ResponsiveMargin.args = {
 };
 ResponsiveMargin.parameters = RESPONSIVE_STORY;
 
-export const ResponsivePadding = BoxTemplate.bind({});
+export const ResponsivePadding: StoryFn<BoxProps> = BoxTemplate.bind({});
 ResponsivePadding.args = {
   propertyName: 'padding',
   padding: {
@@ -713,7 +713,7 @@ const BoxChildrenTemplate: Story<BoxProps> = ({ propertyName, ...args }) => {
   );
 };
 
-export const ResponsiveDirection = BoxChildrenTemplate.bind({});
+export const ResponsiveDirection: Story<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveDirection.args = {
   propertyName: 'direction',
   direction: {
@@ -725,7 +725,7 @@ ResponsiveDirection.args = {
 };
 ResponsiveDirection.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveChildGap = BoxChildrenTemplate.bind({});
+export const ResponsiveChildGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveChildGap.args = {
   propertyName: 'childGap',
   childGap: {
@@ -737,7 +737,7 @@ ResponsiveChildGap.args = {
 };
 ResponsiveChildGap.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveGap = BoxChildrenTemplate.bind({});
+export const ResponsiveGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveGap.args = {
   propertyName: 'gap',
   gap: {
@@ -749,7 +749,7 @@ ResponsiveGap.args = {
 };
 ResponsiveGap.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveRowGap = BoxChildrenTemplate.bind({});
+export const ResponsiveRowGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveRowGap.args = {
   propertyName: 'rowGap',
   rowGap: {
@@ -761,7 +761,7 @@ ResponsiveRowGap.args = {
 };
 ResponsiveRowGap.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveColumnGap = BoxChildrenTemplate.bind({});
+export const ResponsiveColumnGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveColumnGap.args = {
   propertyName: 'columnGap',
   columnGap: {
@@ -931,7 +931,7 @@ export const AllPositionOptions: React.FunctionComponent<BoxProps> = () => (
   </Box>
 );
 
-export const ResponsivePosition = BoxChildrenTemplate.bind({});
+export const ResponsivePosition: Story<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsivePosition.args = {
   propertyName: 'position',
   position: {

--- a/packages/components/src/components/box/box.visual-tests.stories.tsx
+++ b/packages/components/src/components/box/box.visual-tests.stories.tsx
@@ -664,7 +664,7 @@ ResponsivePadding.args = {
 };
 ResponsivePadding.parameters = RESPONSIVE_STORY;
 
-const BoxChildrenTemplate: Story<BoxProps> = ({ propertyName, ...args }) => {
+const BoxChildrenTemplate: StoryFn<BoxProps> = ({ propertyName, ...args }) => {
   const Template: React.FC<Record<string, unknown>> = () => {
     const { activeBreakpoint } = useBreakpoint();
     return (
@@ -713,7 +713,7 @@ const BoxChildrenTemplate: Story<BoxProps> = ({ propertyName, ...args }) => {
   );
 };
 
-export const ResponsiveDirection: Story<BoxProps> = BoxChildrenTemplate.bind({});
+export const ResponsiveDirection: StoryFn<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveDirection.args = {
   propertyName: 'direction',
   direction: {
@@ -725,7 +725,7 @@ ResponsiveDirection.args = {
 };
 ResponsiveDirection.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveChildGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
+export const ResponsiveChildGap: StoryFn<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveChildGap.args = {
   propertyName: 'childGap',
   childGap: {
@@ -737,7 +737,7 @@ ResponsiveChildGap.args = {
 };
 ResponsiveChildGap.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
+export const ResponsiveGap: StoryFn<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveGap.args = {
   propertyName: 'gap',
   gap: {
@@ -749,7 +749,7 @@ ResponsiveGap.args = {
 };
 ResponsiveGap.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveRowGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
+export const ResponsiveRowGap: StoryFn<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveRowGap.args = {
   propertyName: 'rowGap',
   rowGap: {
@@ -761,7 +761,7 @@ ResponsiveRowGap.args = {
 };
 ResponsiveRowGap.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveColumnGap: Story<BoxProps> = BoxChildrenTemplate.bind({});
+export const ResponsiveColumnGap: StoryFn<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsiveColumnGap.args = {
   propertyName: 'columnGap',
   columnGap: {
@@ -931,7 +931,7 @@ export const AllPositionOptions: React.FunctionComponent<BoxProps> = () => (
   </Box>
 );
 
-export const ResponsivePosition: Story<BoxProps> = BoxChildrenTemplate.bind({});
+export const ResponsivePosition: StoryFn<BoxProps> = BoxChildrenTemplate.bind({});
 ResponsivePosition.args = {
   propertyName: 'position',
   position: {

--- a/packages/components/src/components/button/button.playground.stories.tsx
+++ b/packages/components/src/components/button/button.playground.stories.tsx
@@ -81,7 +81,7 @@ export default meta;
 
 const Template: StoryFn<ButtonProps> = ({ ...args }) => <Button {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<ButtonProps> = Template.bind({});
 Playground.args = {
   variant: 'primary',
   children: 'Playground Button',

--- a/packages/components/src/components/button/button.visual-tests.stories.tsx
+++ b/packages/components/src/components/button/button.visual-tests.stories.tsx
@@ -80,20 +80,20 @@ const SingleButtonTemplate: StoryFn<ButtonProps> = args => (
   </div>
 );
 
-export const Sizes = Template.bind({});
+export const Sizes: StoryFn<ButtonProps & { showIconButton: boolean; }> = Template.bind({});
 Sizes.args = { showIconButton: true };
 Sizes.parameters = RESPONSIVE_STORY;
 
-export const Loading = Template.bind({});
+export const Loading: StoryFn<ButtonProps & { showIconButton: boolean; }> = Template.bind({});
 Loading.args = { isLoading: true, showIconButton: true };
 
-export const Disabled = Template.bind({});
+export const Disabled: StoryFn<ButtonProps & { showIconButton: boolean; }> = Template.bind({});
 Disabled.args = { isDisabled: true, showIconButton: true };
 
-export const WithIcons = Template.bind({});
+export const WithIcons: StoryFn<ButtonProps & { showIconButton: boolean; }> = Template.bind({});
 WithIcons.args = { iconPrefix: 'mail', iconSuffix: 'chat' };
 
-export const PrimaryFocus = SingleButtonTemplate.bind({});
+export const PrimaryFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 
 PrimaryFocus.play = async ({ canvasElement }) => {
   // Starts querying the component from its root
@@ -103,7 +103,7 @@ PrimaryFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const SuccessFocus = SingleButtonTemplate.bind({});
+export const SuccessFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 SuccessFocus.args = { variant: 'success' };
 
 SuccessFocus.play = async ({ canvasElement }) => {
@@ -111,7 +111,7 @@ SuccessFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const DangerFocus = SingleButtonTemplate.bind({});
+export const DangerFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 DangerFocus.args = { variant: 'danger' };
 
 DangerFocus.play = async ({ canvasElement }) => {
@@ -119,7 +119,7 @@ DangerFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const LightFocus = SingleButtonTemplate.bind({});
+export const LightFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 LightFocus.args = { variant: 'light' };
 
 LightFocus.play = async ({ canvasElement }) => {
@@ -127,7 +127,7 @@ LightFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const DarkFocus = SingleButtonTemplate.bind({});
+export const DarkFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 DarkFocus.args = { variant: 'dark' };
 
 DarkFocus.play = async ({ canvasElement }) => {
@@ -135,7 +135,7 @@ DarkFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const WhiteFocus = SingleButtonTemplate.bind({});
+export const WhiteFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 WhiteFocus.args = { variant: 'white' };
 
 WhiteFocus.play = async ({ canvasElement }) => {
@@ -143,7 +143,7 @@ WhiteFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const PrimaryOutlinedFocus = SingleButtonTemplate.bind({});
+export const PrimaryOutlinedFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 PrimaryOutlinedFocus.args = { isOutlined: true };
 
 PrimaryOutlinedFocus.play = async ({ canvasElement }) => {
@@ -154,7 +154,7 @@ PrimaryOutlinedFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const SuccessOutlinedFocus = SingleButtonTemplate.bind({});
+export const SuccessOutlinedFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 SuccessOutlinedFocus.args = { variant: 'success', isOutlined: true };
 
 SuccessOutlinedFocus.play = async ({ canvasElement }) => {
@@ -162,7 +162,7 @@ SuccessOutlinedFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const DangerOutlinedFocus = SingleButtonTemplate.bind({});
+export const DangerOutlinedFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 DangerOutlinedFocus.args = { variant: 'danger', isOutlined: true };
 
 DangerOutlinedFocus.play = async ({ canvasElement }) => {
@@ -170,7 +170,7 @@ DangerOutlinedFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const LightOutlinedFocus = SingleButtonTemplate.bind({});
+export const LightOutlinedFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 LightOutlinedFocus.args = { variant: 'light', isOutlined: true };
 
 LightOutlinedFocus.play = async ({ canvasElement }) => {
@@ -178,7 +178,7 @@ LightOutlinedFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const DarkOutlinedFocus = SingleButtonTemplate.bind({});
+export const DarkOutlinedFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 DarkOutlinedFocus.args = { variant: 'dark', isOutlined: true };
 
 DarkOutlinedFocus.play = async ({ canvasElement }) => {
@@ -186,7 +186,7 @@ DarkOutlinedFocus.play = async ({ canvasElement }) => {
   canvas.getByRole('button').focus();
 };
 
-export const WhiteOutlinedFocus = SingleButtonTemplate.bind({});
+export const WhiteOutlinedFocus: StoryFn<ButtonProps> = SingleButtonTemplate.bind({});
 WhiteOutlinedFocus.args = { variant: 'white', isOutlined: true };
 
 WhiteOutlinedFocus.play = async ({ canvasElement }) => {

--- a/packages/components/src/components/card/card.playground.stories.tsx
+++ b/packages/components/src/components/card/card.playground.stories.tsx
@@ -57,7 +57,7 @@ const Template: StoryFn<CardProps> = ({
  * Use the playground to see different results
  */
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<CardProps> = Template.bind({});
 Playground.args = {
   cardTitle: 'Title',
   sectionContent: 'Section content',

--- a/packages/components/src/components/category-filter/category-filter.playground.stories.tsx
+++ b/packages/components/src/components/category-filter/category-filter.playground.stories.tsx
@@ -23,7 +23,7 @@ export default meta;
 
 const Template: StoryFn<CategoryFilterProps> = ({ ...args }) => <CategoryFilter {...args}>My Category</CategoryFilter>;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<CategoryFilterProps> = Template.bind({});
 Playground.args = {
   isSelected: false,
   isDisabled: false,

--- a/packages/components/src/components/category-filter/category-filter.visual-tests.stories.tsx
+++ b/packages/components/src/components/category-filter/category-filter.visual-tests.stories.tsx
@@ -54,7 +54,7 @@ const Template: StoryFn<CategoryFilterProps> = ({ ...args }) => (
   </Box>
 );
 
-export const SizesAndStates = Template.bind({});
+export const SizesAndStates: StoryFn<CategoryFilterProps> = Template.bind({});
 
 export const ResponsiveSize: ComponentStory<typeof CategoryFilter> = () => (
   <CategoryFilter

--- a/packages/components/src/components/checkbox-input/checkbox-input.playground.stories.tsx
+++ b/packages/components/src/components/checkbox-input/checkbox-input.playground.stories.tsx
@@ -47,7 +47,7 @@ export default meta;
 
 const Template: StoryFn<CheckboxInputProps> = ({ ...args }) => <CheckboxInput {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<CheckboxInputProps> = Template.bind({});
 Playground.args = {
   id: 'playGroundCheckbox',
   label: 'Playground Checkbox',

--- a/packages/components/src/components/checkbox-input/checkbox-input.visual-tests.stories.tsx
+++ b/packages/components/src/components/checkbox-input/checkbox-input.visual-tests.stories.tsx
@@ -15,7 +15,7 @@ const Template: StoryFn<CheckboxInputProps> = ({ ...args }) => (
   <CheckboxInput {...args} onChange={() => {}} /> // eslint-disable-line @typescript-eslint/no-empty-function
 );
 
-export const ResponsiveSizeOneUnchecked = Template.bind({});
+export const ResponsiveSizeOneUnchecked: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeOneUnchecked.args = {
   id: 'ResponsiveSizeOneUnchecked',
   label: 'ResponsiveSizeOneUnchecked',
@@ -29,7 +29,7 @@ ResponsiveSizeOneUnchecked.args = {
 };
 ResponsiveSizeOneUnchecked.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeTwoUnchecked = Template.bind({});
+export const ResponsiveSizeTwoUnchecked: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeTwoUnchecked.args = {
   id: 'ResponsiveSizeTwoUnchecked',
   label: 'ResponsiveSizeTwoUnchecked',
@@ -43,7 +43,7 @@ ResponsiveSizeTwoUnchecked.args = {
 };
 ResponsiveSizeTwoUnchecked.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeThreeUnchecked = Template.bind({});
+export const ResponsiveSizeThreeUnchecked: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeThreeUnchecked.args = {
   id: 'ResponsiveSizeThreeUnchecked',
   label: 'ResponsiveSizeThreeUnchecked',
@@ -57,7 +57,7 @@ ResponsiveSizeThreeUnchecked.args = {
 };
 ResponsiveSizeThreeUnchecked.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeOneChecked = Template.bind({});
+export const ResponsiveSizeOneChecked: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeOneChecked.args = {
   id: 'ResponsiveSizeOneChecked',
   label: 'ResponsiveSizeOneChecked',
@@ -71,7 +71,7 @@ ResponsiveSizeOneChecked.args = {
 };
 ResponsiveSizeOneChecked.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeTwoChecked = Template.bind({});
+export const ResponsiveSizeTwoChecked: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeTwoChecked.args = {
   id: 'ResponsiveSizeTwoChecked',
   label: 'ResponsiveSizeTwoChecked',
@@ -85,7 +85,7 @@ ResponsiveSizeTwoChecked.args = {
 };
 ResponsiveSizeTwoChecked.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeThreeChecked = Template.bind({});
+export const ResponsiveSizeThreeChecked: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeThreeChecked.args = {
   id: 'ResponsiveSizeThreeChecked',
   label: 'ResponsiveSizeThreeChecked',
@@ -99,7 +99,7 @@ ResponsiveSizeThreeChecked.args = {
 };
 ResponsiveSizeThreeChecked.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeOneIndeterminate = Template.bind({});
+export const ResponsiveSizeOneIndeterminate: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeOneIndeterminate.args = {
   id: 'ResponsiveSizeOneIndeterminate',
   label: 'ResponsiveSizeOneIndeterminate',
@@ -114,7 +114,7 @@ ResponsiveSizeOneIndeterminate.args = {
 };
 ResponsiveSizeOneIndeterminate.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeTwoIndeterminate = Template.bind({});
+export const ResponsiveSizeTwoIndeterminate: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeTwoIndeterminate.args = {
   id: 'ResponsiveSizeTwoIndeterminate',
   label: 'ResponsiveSizeTwoIndeterminate',
@@ -129,7 +129,7 @@ ResponsiveSizeTwoIndeterminate.args = {
 };
 ResponsiveSizeTwoIndeterminate.parameters = RESPONSIVE_STORY;
 
-export const ResponsiveSizeThreeIndeterminate = Template.bind({});
+export const ResponsiveSizeThreeIndeterminate: StoryFn<CheckboxInputProps> = Template.bind({});
 ResponsiveSizeThreeIndeterminate.args = {
   id: 'ResponsiveSizeThreeIndeterminate',
   label: 'ResponsiveSizeThreeIndeterminate',
@@ -144,7 +144,7 @@ ResponsiveSizeThreeIndeterminate.args = {
 };
 ResponsiveSizeThreeIndeterminate.parameters = RESPONSIVE_STORY;
 
-export const FocusChecked = Template.bind({});
+export const FocusChecked: StoryFn<CheckboxInputProps> = Template.bind({});
 FocusChecked.args = {
   id: 'FocusUnchecked',
   label: 'Focus Checked',
@@ -156,7 +156,7 @@ FocusChecked.play = async ({ canvasElement }) => {
   canvas.getByRole('checkbox').focus();
 };
 
-export const FocusUnchecked = Template.bind({});
+export const FocusUnchecked: StoryFn<CheckboxInputProps> = Template.bind({});
 FocusUnchecked.args = {
   id: 'FocusUnchecked',
   label: 'Focus Unchecked',
@@ -168,7 +168,7 @@ FocusUnchecked.play = async ({ canvasElement }) => {
   canvas.getByRole('checkbox').focus();
 };
 
-export const FocusErrorChecked = Template.bind({});
+export const FocusErrorChecked: StoryFn<CheckboxInputProps> = Template.bind({});
 FocusErrorChecked.args = {
   id: 'FocusErrorChecked',
   label: 'Focus Error Checked',
@@ -181,7 +181,7 @@ FocusErrorChecked.play = async ({ canvasElement }) => {
   canvas.getByRole('checkbox').focus();
 };
 
-export const FocusErrorUnchecked = Template.bind({});
+export const FocusErrorUnchecked: StoryFn<CheckboxInputProps> = Template.bind({});
 FocusErrorUnchecked.args = {
   id: 'FocusErrorUnchecked',
   label: 'Focus Error Unchecked',

--- a/packages/components/src/components/details/details.playground.stories.tsx
+++ b/packages/components/src/components/details/details.playground.stories.tsx
@@ -36,7 +36,7 @@ const Template: StoryFn<DetailsProps> = ({
 /**
  * Use the playground to see different results
  */
-export const Playground = Template.bind({});
+export const Playground: StoryFn<DetailsProps> = Template.bind({});
 
 Playground.args = {
   isOpen: false,

--- a/packages/components/src/components/duration/durations.playground.stories.tsx
+++ b/packages/components/src/components/duration/durations.playground.stories.tsx
@@ -43,7 +43,7 @@ export default meta;
 
 const Template: StoryFn<DurationProps> = ({ ...args }) => <Duration {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<DurationProps> = Template.bind({});
 
 Playground.args = {
   milliseconds: 6000000,

--- a/packages/components/src/components/file-upload/file-upload.playground.stories.tsx
+++ b/packages/components/src/components/file-upload/file-upload.playground.stories.tsx
@@ -77,7 +77,7 @@ const Template: StoryFn<FileUploadProps> = ({ ...args }) => (
   <FileUpload {...args} />
 );
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<FileUploadProps> = Template.bind({});
 Playground.args = {
   id: 'playGroundFileUpload',
   buttonText: 'Playground FileUpload',

--- a/packages/components/src/components/file-upload/file-upload.visual-tests.stories.tsx
+++ b/packages/components/src/components/file-upload/file-upload.visual-tests.stories.tsx
@@ -14,7 +14,7 @@ const Template: StoryFn<FileUploadProps> = ({ ...args }) => (
   <FileUpload {...args}>category filter</FileUpload> // eslint-disable-line @typescript-eslint/no-empty-function
 );
 
-export const ResponsiveHelpText = Template.bind({});
+export const ResponsiveHelpText: StoryFn<FileUploadProps> = Template.bind({});
 ResponsiveHelpText.args = {
   helpText: 'image files only (jpg, png, gif)',
   accept: 'image/*',

--- a/packages/components/src/components/form-label/form-label.playground.stories.tsx
+++ b/packages/components/src/components/form-label/form-label.playground.stories.tsx
@@ -28,7 +28,7 @@ export default meta;
 
 const Template: StoryFn<FormLabelProps> = ({ ...args }) => <FormLabel {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<FormLabelProps> = Template.bind({});
 Playground.args = {
   inputId: 'playgroundInput',
   children: 'Playground Form Label',

--- a/packages/components/src/components/heading/heading.playground.stories.tsx
+++ b/packages/components/src/components/heading/heading.playground.stories.tsx
@@ -39,7 +39,7 @@ export default meta;
 
 const Template: StoryFn<HeadingProps> = ({ ...args }) => <Heading {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<HeadingProps> = Template.bind({});
 Playground.args = {
   as: 'h4',
   children: 'Lead the world towards a clean energy future',

--- a/packages/components/src/components/heading/heading.visual-tests.stories.tsx
+++ b/packages/components/src/components/heading/heading.visual-tests.stories.tsx
@@ -33,12 +33,12 @@ const VariantTemplate: StoryFn<HeadingProps> = args => (
   </Box>
 );
 
-export const Size = SizeTemplate.bind({});
+export const Size: StoryFn<HeadingProps> = SizeTemplate.bind({});
 Size.args = {
   children: 'Hello world!',
 };
 
-export const Variant = VariantTemplate.bind({});
+export const Variant: StoryFn<HeadingProps> = VariantTemplate.bind({});
 Variant.args = {
   children: 'Hello world!',
 };

--- a/packages/components/src/components/icon/icon.playground.stories.tsx
+++ b/packages/components/src/components/icon/icon.playground.stories.tsx
@@ -32,7 +32,7 @@ export default meta;
 
 const Template: StoryFn<IconProps> = ({ ...args }) => <Icon {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<IconProps> = Template.bind({});
 Playground.args = {
   name: 'home',
   size: '5xl',

--- a/packages/components/src/components/icon/icon.visual-tests.stories.tsx
+++ b/packages/components/src/components/icon/icon.visual-tests.stories.tsx
@@ -32,7 +32,7 @@ export const SizeAndColor: React.FunctionComponent<IconProps> = () => (
 
 const IconTemplate: StoryFn<IconProps> = ({ ...args }) => <Icon {...args} />;
 
-export const ResponsiveSize = IconTemplate.bind({});
+export const ResponsiveSize: StoryFn<IconProps> = IconTemplate.bind({});
 ResponsiveSize.args = {
   name: 'home',
   size: {

--- a/packages/components/src/components/option-tile-group/option-tile-group.playground.stories.tsx
+++ b/packages/components/src/components/option-tile-group/option-tile-group.playground.stories.tsx
@@ -84,7 +84,7 @@ const Template: StoryFn<OptionTileGroupProps> = ({
   />
 );
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<OptionTileGroupProps> = Template.bind({});
 
 Playground.args = {
   value: null,

--- a/packages/components/src/components/option-tile-group/option-tile-group.visual-tests.stories.tsx
+++ b/packages/components/src/components/option-tile-group/option-tile-group.visual-tests.stories.tsx
@@ -35,27 +35,27 @@ const Template: StoryFn<OptionTileGroupProps> = args => (
   />
 );
 
-export const DefaultRadio = Template.bind({});
+export const DefaultRadio: StoryFn<OptionTileGroupProps> = Template.bind({});
 DefaultRadio.args = {
   options,
   name: 'default',
 };
 
-export const RadioOptionSelected = Template.bind({});
+export const RadioOptionSelected: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioOptionSelected.args = {
   options,
   value: 'chocolate',
   name: 'optionSelected',
 };
 
-export const MultipleOptionsNoneSelected = Template.bind({});
+export const MultipleOptionsNoneSelected: StoryFn<OptionTileGroupProps> = Template.bind({});
 MultipleOptionsNoneSelected.args = {
   options,
   name: 'multiNone',
   isMulti: true,
 };
 
-export const MultipleOptionsOneSelected = Template.bind({});
+export const MultipleOptionsOneSelected: StoryFn<OptionTileGroupProps> = Template.bind({});
 MultipleOptionsOneSelected.args = {
   options,
   name: 'multiOne',
@@ -63,7 +63,7 @@ MultipleOptionsOneSelected.args = {
   value: ['chocolate'],
 };
 
-export const MultipleOptionsAllSelected = Template.bind({});
+export const MultipleOptionsAllSelected: StoryFn<OptionTileGroupProps> = Template.bind({});
 MultipleOptionsAllSelected.args = {
   options,
   name: 'multiAll',
@@ -71,7 +71,7 @@ MultipleOptionsAllSelected.args = {
   value: ['chocolate', 'vanilla', 'strawberry'],
 };
 
-export const RadioWithDisabledOption = Template.bind({});
+export const RadioWithDisabledOption: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithDisabledOption.args = {
   options: [
     ...options,
@@ -85,7 +85,7 @@ RadioWithDisabledOption.args = {
   name: 'radioOneDisabled',
 };
 
-export const RadioWithDisabledOptionSelected = Template.bind({});
+export const RadioWithDisabledOptionSelected: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithDisabledOptionSelected.args = {
   options: [
     ...options,
@@ -100,7 +100,7 @@ RadioWithDisabledOptionSelected.args = {
   value: 'cookies',
 };
 
-export const CheckboxWithDisabledOption = Template.bind({});
+export const CheckboxWithDisabledOption: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithDisabledOption.args = {
   options: [
     ...options,
@@ -115,7 +115,7 @@ CheckboxWithDisabledOption.args = {
   isMulti: true,
 };
 
-export const CheckboxWithDisabledOptionSelected = Template.bind({});
+export const CheckboxWithDisabledOptionSelected: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithDisabledOptionSelected.args = {
   options: [
     ...options,
@@ -131,7 +131,7 @@ CheckboxWithDisabledOptionSelected.args = {
   isMulti: true,
 };
 
-export const RadioWithTitle = Template.bind({});
+export const RadioWithTitle: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithTitle.args = {
   options: [
     ...options,
@@ -140,7 +140,7 @@ RadioWithTitle.args = {
   title: 'Ice cream flavors',
 };
 
-export const RadioWithTitleRequired = Template.bind({});
+export const RadioWithTitleRequired: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithTitleRequired.args = {
   options: [
     ...options,
@@ -150,7 +150,7 @@ RadioWithTitleRequired.args = {
   isRequired: true,
 };
 
-export const RadioWithTitleAndDescription = Template.bind({});
+export const RadioWithTitleAndDescription: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithTitleAndDescription.args = {
   options: [
     ...options,
@@ -160,7 +160,7 @@ RadioWithTitleAndDescription.args = {
   description: 'Only if you finish your dinner',
 };
 
-export const RadioWithDescriptionOnly = Template.bind({});
+export const RadioWithDescriptionOnly: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithDescriptionOnly.args = {
   options: [
     ...options,
@@ -169,7 +169,7 @@ RadioWithDescriptionOnly.args = {
   description: 'Only if you finish your dinner',
 };
 
-export const CheckboxWithTitle = Template.bind({});
+export const CheckboxWithTitle: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithTitle.args = {
   options: [
     ...options,
@@ -179,7 +179,7 @@ CheckboxWithTitle.args = {
   isMulti: true,
 };
 
-export const CheckboxWithTitleAndDescription = Template.bind({});
+export const CheckboxWithTitleAndDescription: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithTitleAndDescription.args = {
   options: [
     ...options,
@@ -190,7 +190,7 @@ CheckboxWithTitleAndDescription.args = {
   isMulti: true,
 };
 
-export const CheckboxWithDescriptionOnly = Template.bind({});
+export const CheckboxWithDescriptionOnly: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithDescriptionOnly.args = {
   options: [
     ...options,
@@ -200,7 +200,7 @@ CheckboxWithDescriptionOnly.args = {
   isMulti: true,
 };
 
-export const RadioWithError = Template.bind({});
+export const RadioWithError: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithError.args = {
   options: [
     ...options,
@@ -209,7 +209,7 @@ RadioWithError.args = {
   error: true,
 };
 
-export const RadioWithErrorTitleAndDescription = Template.bind({});
+export const RadioWithErrorTitleAndDescription: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithErrorTitleAndDescription.args = {
   options: [
     ...options,
@@ -220,7 +220,7 @@ RadioWithErrorTitleAndDescription.args = {
   description: 'Only if you finish your dinner',
 };
 
-export const RadioRequiredWithErrorTitleAndDescription = Template.bind({});
+export const RadioRequiredWithErrorTitleAndDescription: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioRequiredWithErrorTitleAndDescription.args = {
   options: [
     ...options,
@@ -232,7 +232,7 @@ RadioRequiredWithErrorTitleAndDescription.args = {
   isRequired: true,
 };
 
-export const RadioWithErrorMessage = Template.bind({});
+export const RadioWithErrorMessage: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithErrorMessage.args = {
   options: [
     ...options,
@@ -241,7 +241,7 @@ RadioWithErrorMessage.args = {
   error: 'something is wrong',
 };
 
-export const RadioWithErrorMessageTitleAndDescription = Template.bind({});
+export const RadioWithErrorMessageTitleAndDescription: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithErrorMessageTitleAndDescription.args = {
   options: [
     ...options,
@@ -252,7 +252,7 @@ RadioWithErrorMessageTitleAndDescription.args = {
   error: 'something is wrong',
 };
 
-export const RadioRequiredWithErrorMessageTitleAndDescription = Template.bind({});
+export const RadioRequiredWithErrorMessageTitleAndDescription: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioRequiredWithErrorMessageTitleAndDescription.args = {
   options: [
     ...options,
@@ -264,7 +264,7 @@ RadioRequiredWithErrorMessageTitleAndDescription.args = {
   error: 'something is wrong',
 };
 
-export const RadioWithErrorAndSelectedOption = Template.bind({});
+export const RadioWithErrorAndSelectedOption: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithErrorAndSelectedOption.args = {
   options: [
     ...options,
@@ -274,7 +274,7 @@ RadioWithErrorAndSelectedOption.args = {
   value: 'chocolate',
 };
 
-export const RadioWithErrorAndSelectedDisabledOption = Template.bind({});
+export const RadioWithErrorAndSelectedDisabledOption: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithErrorAndSelectedDisabledOption.args = {
   options: [
     ...options,
@@ -290,7 +290,7 @@ RadioWithErrorAndSelectedDisabledOption.args = {
   value: 'cookies',
 };
 
-export const CheckboxWithErrorAndSelectedOption = Template.bind({});
+export const CheckboxWithErrorAndSelectedOption: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithErrorAndSelectedOption.args = {
   options: [
     ...options,
@@ -301,7 +301,7 @@ CheckboxWithErrorAndSelectedOption.args = {
   isMulti: true,
 };
 
-export const CheckboxWithErrorAndSelectedDisabledOption = Template.bind({});
+export const CheckboxWithErrorAndSelectedDisabledOption: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithErrorAndSelectedDisabledOption.args = {
   options: [
     ...options,
@@ -318,7 +318,7 @@ CheckboxWithErrorAndSelectedDisabledOption.args = {
   value: ['cookies'],
 };
 
-export const RadioWithHorizontalDirection = Template.bind({});
+export const RadioWithHorizontalDirection: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithHorizontalDirection.args = {
   options: [
     ...options,
@@ -327,7 +327,7 @@ RadioWithHorizontalDirection.args = {
   direction: 'row',
 };
 
-export const RadioWithContentWidthVertical = Template.bind({});
+export const RadioWithContentWidthVertical: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithContentWidthVertical.args = {
   options: [
     ...options,
@@ -336,7 +336,7 @@ RadioWithContentWidthVertical.args = {
   isFullWidth: false,
 };
 
-export const RadioWithContentWidthHorizontal = Template.bind({});
+export const RadioWithContentWidthHorizontal: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithContentWidthHorizontal.args = {
   options: [
     ...options,
@@ -346,7 +346,7 @@ RadioWithContentWidthHorizontal.args = {
   direction: 'row',
 };
 
-export const RadioWithCustomContent = Template.bind({});
+export const RadioWithCustomContent: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithCustomContent.args = {
   options: [
     ...options,
@@ -360,7 +360,7 @@ RadioWithCustomContent.args = {
   name: 'radioWithCustomContent',
 };
 
-export const CheckboxWithCustomContent = Template.bind({});
+export const CheckboxWithCustomContent: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithCustomContent.args = {
   options: [
     ...options,
@@ -375,7 +375,7 @@ CheckboxWithCustomContent.args = {
   isMulti: true,
 };
 
-export const RadioWithHiddenRadio = Template.bind({});
+export const RadioWithHiddenRadio: StoryFn<OptionTileGroupProps> = Template.bind({});
 RadioWithHiddenRadio.args = {
   options: [
     ...options,
@@ -384,7 +384,7 @@ RadioWithHiddenRadio.args = {
   name: 'radioWithHiddenRadio',
 };
 
-export const CheckboxWithHiddenCheckbox = Template.bind({});
+export const CheckboxWithHiddenCheckbox: StoryFn<OptionTileGroupProps> = Template.bind({});
 CheckboxWithHiddenCheckbox.args = {
   options: [
     ...options,
@@ -394,7 +394,7 @@ CheckboxWithHiddenCheckbox.args = {
   isMulti: true,
 };
 
-export const ResponsiveDirection = Template.bind({});
+export const ResponsiveDirection: StoryFn<OptionTileGroupProps> = Template.bind({});
 ResponsiveDirection.args = {
   options: [
     ...options,

--- a/packages/components/src/components/option-tile/option-tile.visual-tests.stories.tsx
+++ b/packages/components/src/components/option-tile/option-tile.visual-tests.stories.tsx
@@ -89,7 +89,7 @@ const Template: StoryFn<OptionTileProps> = args => (
   </OptionTile>
 );
 
-export const FocusUnchecked = Template.bind({});
+export const FocusUnchecked: StoryFn<OptionTileProps> = Template.bind({});
 FocusUnchecked.args = {
   isSelected: false,
   children: 'radio unchecked',
@@ -104,7 +104,7 @@ FocusUnchecked.play = async ({ canvasElement }) => {
   canvas.getByRole('radio').focus();
 };
 
-export const FocusChecked = Template.bind({});
+export const FocusChecked: StoryFn<OptionTileProps> = Template.bind({});
 FocusChecked.args = {
   isSelected: true,
   children: 'radio selected',

--- a/packages/components/src/components/pagination/pagination.playground.stories.tsx
+++ b/packages/components/src/components/pagination/pagination.playground.stories.tsx
@@ -35,7 +35,7 @@ export default meta;
 const Template: StoryFn<PaginationProps> = ({ ...args }) => (
   <Pagination {...args} />
 );
-export const Playground = Template.bind({});
+export const Playground: StoryFn<PaginationProps> = Template.bind({});
 Playground.args = {
   arePagesVisible: true,
   activePage: 1,

--- a/packages/components/src/components/radio-group/radio-group.playground.stories.tsx
+++ b/packages/components/src/components/radio-group/radio-group.playground.stories.tsx
@@ -50,7 +50,7 @@ export default meta;
 
 const Template: StoryFn<RadioGroupProps> = ({ ...args }) => <RadioGroup {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<RadioGroupProps> = Template.bind({});
 Playground.args = {
   title: 'Playground Radiogroup',
   description: 'Choose your favorite flavor',

--- a/packages/components/src/components/radio-group/radio-group.visual-tests.stories.tsx
+++ b/packages/components/src/components/radio-group/radio-group.visual-tests.stories.tsx
@@ -54,10 +54,10 @@ const Template: StoryFn<RadioGroupProps> = ({ ...args }) => (
   </Box>
 );
 
-export const AllSizes = Template.bind({});
+export const AllSizes: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizes.args = { id: 'AllSizes' };
 
-export const AllSizesChecked = Template.bind({});
+export const AllSizesChecked: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesChecked.args = {
   id: 'AllSizesChecked',
   isRequired: true,
@@ -66,30 +66,30 @@ AllSizesChecked.args = {
 };
 AllSizesChecked.parameters = RESPONSIVE_STORY;
 
-export const AllSizesError = Template.bind({});
+export const AllSizesError: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesError.args = { id: 'AllSizesError', error: 'Agreement is required' };
 
-export const AllSizesDisabled = Template.bind({});
+export const AllSizesDisabled: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesDisabled.args = { id: 'AllSizesDisabled', isDisabled: true };
 
-export const AllSizesDisabledChecked = Template.bind({});
+export const AllSizesDisabledChecked: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesDisabledChecked.args = {
   id: 'AllSizesDisabledChecked',
   isDisabled: true,
   value: 'one',
 };
 
-export const AllSizesTitle = Template.bind({});
+export const AllSizesTitle: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesTitle.args = { id: 'AllSizesTitle', title: 'title' };
 
-export const AllSizesTitleDisabled = Template.bind({});
+export const AllSizesTitleDisabled: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesTitleDisabled.args = {
   id: 'AllSizesTitleDisabled',
   title: 'title',
   isDisabled: true,
 };
 
-export const AllSizesTitleDisabledError = Template.bind({});
+export const AllSizesTitleDisabledError: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesTitleDisabledError.args = {
   id: 'AllSizesTitleDisabledError',
   title: 'title',
@@ -97,7 +97,7 @@ AllSizesTitleDisabledError.args = {
   error: 'this is required',
 };
 
-export const AllSizesTitleDisabledErrorChecked = Template.bind({});
+export const AllSizesTitleDisabledErrorChecked: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesTitleDisabledErrorChecked.args = {
   id: 'AllSizesTitleDisabledErrorChecked',
   title: 'title',
@@ -106,7 +106,7 @@ AllSizesTitleDisabledErrorChecked.args = {
   value: 'one',
 };
 
-export const AllSizesTitleDisabledOption = Template.bind({});
+export const AllSizesTitleDisabledOption: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesTitleDisabledOption.args = {
   id: 'AllSizesTitleDisabledOption',
   title: 'title',
@@ -122,7 +122,7 @@ AllSizesTitleDisabledOption.args = {
   ],
 };
 
-export const AllSizesTitleDisabledOptionSelected = Template.bind({});
+export const AllSizesTitleDisabledOptionSelected: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesTitleDisabledOptionSelected.args = {
   id: 'AllSizesTitleDisabledOptionSelected',
   title: 'title',
@@ -138,10 +138,10 @@ AllSizesTitleDisabledOptionSelected.args = {
   ],
 };
 
-export const AllSizesHorizontal = Template.bind({});
+export const AllSizesHorizontal: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontal.args = { id: 'AllSizesHorizontal', direction: 'row' };
 
-export const AllSizesHorizontalChecked = Template.bind({});
+export const AllSizesHorizontalChecked: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalChecked.args = {
   id: 'AllSizesHorizontalRequired',
   isRequired: true,
@@ -150,21 +150,21 @@ AllSizesHorizontalChecked.args = {
   direction: 'row',
 };
 
-export const AllSizesHorizontalError = Template.bind({});
+export const AllSizesHorizontalError: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalError.args = {
   id: 'AllSizesHorizontalError',
   error: 'Agreement is required',
   direction: 'row',
 };
 
-export const AllSizesHorizontalDisabled = Template.bind({});
+export const AllSizesHorizontalDisabled: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalDisabled.args = {
   id: 'AllSizesHorizontalDisabled',
   isDisabled: true,
   direction: 'row',
 };
 
-export const AllSizesHorizontalDisabledChecked = Template.bind({});
+export const AllSizesHorizontalDisabledChecked: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalDisabledChecked.args = {
   id: 'AllSizesHorizontalDisabled',
   isDisabled: true,
@@ -172,14 +172,14 @@ AllSizesHorizontalDisabledChecked.args = {
   direction: 'row',
 };
 
-export const AllSizesHorizontalTitle = Template.bind({});
+export const AllSizesHorizontalTitle: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalTitle.args = {
   id: 'AllSizesHorizontalTitle',
   title: 'title',
   direction: 'row',
 };
 
-export const AllSizesHorizontalTitleDisabled = Template.bind({});
+export const AllSizesHorizontalTitleDisabled: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalTitleDisabled.args = {
   id: 'AllSizesHorizontalTitleDisabled',
   title: 'title',
@@ -187,7 +187,7 @@ AllSizesHorizontalTitleDisabled.args = {
   direction: 'row',
 };
 
-export const AllSizesHorizontalTitleDisabledError = Template.bind({});
+export const AllSizesHorizontalTitleDisabledError: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalTitleDisabledError.args = {
   id: 'AllSizesHorizontalTitleDisabledError',
   title: 'title',
@@ -196,7 +196,7 @@ AllSizesHorizontalTitleDisabledError.args = {
   direction: 'row',
 };
 
-export const AllSizesHorizontalTitleDisabledErrorChecked = Template.bind({});
+export const AllSizesHorizontalTitleDisabledErrorChecked: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalTitleDisabledErrorChecked.args = {
   id: 'AllSizesHorizontalTitleDisabledErrorChecked',
   title: 'title',
@@ -206,7 +206,7 @@ AllSizesHorizontalTitleDisabledErrorChecked.args = {
   direction: 'row',
 };
 
-export const AllSizesHorizontalTitleDisabledOption = Template.bind({});
+export const AllSizesHorizontalTitleDisabledOption: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalTitleDisabledOption.args = {
   id: 'AllSizesHorizontalTitleDisabledOption',
   title: 'title',
@@ -223,7 +223,7 @@ AllSizesHorizontalTitleDisabledOption.args = {
   direction: 'row',
 };
 
-export const AllSizesHorizontalTitleDisabledOptionSelected = Template.bind({});
+export const AllSizesHorizontalTitleDisabledOptionSelected: StoryFn<RadioGroupProps> = Template.bind({});
 AllSizesHorizontalTitleDisabledOptionSelected.args = {
   id: 'AllSizesHorizontalTitleDisabledOptionSelected',
   title: 'title',
@@ -244,7 +244,7 @@ const SimpleTemplate: StoryFn<RadioGroupProps> = ({ ...args }) => (
   <RadioGroup {...args} options={options} />
 );
 
-export const FocusSelected = SimpleTemplate.bind({});
+export const FocusSelected: StoryFn<RadioGroupProps> = SimpleTemplate.bind({});
 FocusSelected.args = {
   id: 'FocusSelected',
   isRequired: true,
@@ -259,7 +259,7 @@ FocusSelected.play = async ({ canvasElement }) => {
   radios[0].focus();
 };
 
-export const FocusUnselected = SimpleTemplate.bind({});
+export const FocusUnselected: StoryFn<RadioGroupProps> = SimpleTemplate.bind({});
 FocusUnselected.args = {
   id: 'AllSizesChecked',
   isRequired: true,

--- a/packages/components/src/components/select-input-native/select-input-native.playground.stories.tsx
+++ b/packages/components/src/components/select-input-native/select-input-native.playground.stories.tsx
@@ -60,7 +60,7 @@ export default meta;
 
 const Template: StoryFn<SelectInputNativeProps> = ({ ...args }) => <SelectInputNative {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<SelectInputNativeProps> = Template.bind({});
 Playground.args = {
   id: 'playgroundSelectInputNative',
   label: 'Playground SelectInputNative',

--- a/packages/components/src/components/select-input/select-input.playground.stories.tsx
+++ b/packages/components/src/components/select-input/select-input.playground.stories.tsx
@@ -64,7 +64,7 @@ export default meta;
 
 const Template: StoryFn<SelectInputProps> = ({ ...args }) => <SelectInput {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<SelectInputProps> = Template.bind({});
 Playground.args = {
   id: 'playgroundSelectInput',
   label: 'Playground SelectInput',

--- a/packages/components/src/components/spinner/spinner.playground.stories.tsx
+++ b/packages/components/src/components/spinner/spinner.playground.stories.tsx
@@ -30,7 +30,7 @@ export default meta;
 
 const Template: StoryFn<SpinnerProps> = ({ ...args }) => <Spinner {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<SpinnerProps> = Template.bind({});
 Playground.args = {
   variant: 'primary',
 };

--- a/packages/components/src/components/spinner/spinner.visual-tests.stories.tsx
+++ b/packages/components/src/components/spinner/spinner.visual-tests.stories.tsx
@@ -26,4 +26,4 @@ const Template: StoryFn<SpinnerProps> = args => (
   </Box>
 );
 
-export const VariantsAndSizes = Template.bind({});
+export const VariantsAndSizes: StoryFn<SpinnerProps> = Template.bind({});

--- a/packages/components/src/components/tabs-slider/tabs-slider.playground.stories.tsx
+++ b/packages/components/src/components/tabs-slider/tabs-slider.playground.stories.tsx
@@ -69,7 +69,7 @@ const Template: StoryFn<TabsSliderProps> = ({
   </Box>
 );
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<TabsSliderProps> = Template.bind({});
 
 Playground.args = {
   value: 0,

--- a/packages/components/src/components/tabs-slider/tabs-slider.visual-tests.stories.tsx
+++ b/packages/components/src/components/tabs-slider/tabs-slider.visual-tests.stories.tsx
@@ -19,7 +19,7 @@ const Template: StoryFn<TabsSliderProps> = ({ ...args }) => (
   </TabsSlider>
 );
 
-export const ResponsiveSize = Template.bind({});
+export const ResponsiveSize: StoryFn<TabsSliderProps> = Template.bind({});
 ResponsiveSize.args = {
   value: 0,
   size: {

--- a/packages/components/src/components/tabs/tabs.playground.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.playground.stories.tsx
@@ -79,7 +79,7 @@ const Template: StoryFn<TabsProps> = ({
   </Box>
 );
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<TabsProps> = Template.bind({});
 
 Playground.args = {
   value: 0,

--- a/packages/components/src/components/tabs/tabs.visual-tests.stories.tsx
+++ b/packages/components/src/components/tabs/tabs.visual-tests.stories.tsx
@@ -23,13 +23,13 @@ const Template: StoryFn<TabsProps> = ({ ...args }) => (
   </Tabs>
 );
 
-export const ManyTabs = Template.bind({});
+export const ManyTabs: StoryFn<TabsProps> = Template.bind({});
 ManyTabs.args = {
   value: 0,
 };
 ManyTabs.parameters = RESPONSIVE_STORY;
 
-export const ManyTabsLastSelected = Template.bind({});
+export const ManyTabsLastSelected: StoryFn<TabsProps> = Template.bind({});
 ManyTabsLastSelected.args = {
   value: 7,
 };

--- a/packages/components/src/components/text-input/text-input.playground.stories.tsx
+++ b/packages/components/src/components/text-input/text-input.playground.stories.tsx
@@ -82,7 +82,7 @@ export default meta;
 
 const Template: StoryFn<TextInputProps> = ({ ...args }) => <TextInput {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<TextInputProps> = Template.bind({});
 Playground.args = {
   id: 'playgroundTextInput',
   label: 'Playground TextInput',

--- a/packages/components/src/components/text-input/text-input.visual-tests.stories.tsx
+++ b/packages/components/src/components/text-input/text-input.visual-tests.stories.tsx
@@ -141,7 +141,7 @@ export const PrefixSuffixSizes: React.FC = (): ReactElement => {
   );
 };
 
-export const ResponsiveSize = Template.bind({});
+export const ResponsiveSize: StoryFn<TextInputProps> = Template.bind({});
 ResponsiveSize.args = {
   size: {
     base: 'sm',
@@ -155,46 +155,46 @@ ResponsiveSize.args = {
 };
 ResponsiveSize.parameters = RESPONSIVE_STORY;
 
-export const Disabled = Template.bind({});
+export const Disabled: StoryFn<TextInputProps> = Template.bind({});
 Disabled.args = {
   label: 'Disabled TextInput',
   isDisabled: true,
 };
 
-export const DisabledPlaceholder = Template.bind({});
+export const DisabledPlaceholder: StoryFn<TextInputProps> = Template.bind({});
 DisabledPlaceholder.args = {
   label: 'Disabled TextInput',
   isDisabled: true,
   placeholder: 'placeholder text',
 };
 
-export const Error = Template.bind({});
+export const Error: StoryFn<TextInputProps> = Template.bind({});
 Error.args = {
   label: 'Error TextInput',
   error: true,
 };
 
-export const ErrorValidationMessageRequired = Template.bind({});
+export const ErrorValidationMessageRequired: StoryFn<TextInputProps> = Template.bind({});
 ErrorValidationMessageRequired.args = {
   label: 'Error TextInput',
   isRequired: true,
   error: 'Helpful validation message',
 };
 
-export const ErrorValidationMessage = Template.bind({});
+export const ErrorValidationMessage: StoryFn<TextInputProps> = Template.bind({});
 ErrorValidationMessage.args = {
   label: 'Error TextInput',
   error: 'Helpful validation message',
 };
 
-export const ErrorHiddenLabelValidationMessage = Template.bind({});
+export const ErrorHiddenLabelValidationMessage: StoryFn<TextInputProps> = Template.bind({});
 ErrorHiddenLabelValidationMessage.args = {
   label: 'Error TextInput',
   hideLabel: true,
   error: 'Helpful validation message',
 };
 
-export const DefaultFocus = Template.bind({});
+export const DefaultFocus: StoryFn<TextInputProps> = Template.bind({});
 
 DefaultFocus.args = {
   label: 'Default Focus',
@@ -205,7 +205,7 @@ DefaultFocus.play = async ({ canvasElement }) => {
   canvas.getByLabelText('Default Focus').focus();
 };
 
-export const ErrorFocus = Template.bind({});
+export const ErrorFocus: StoryFn<TextInputProps> = Template.bind({});
 
 ErrorFocus.args = {
   label: 'Error Focus',

--- a/packages/components/src/components/textarea-input/textarea-input.playground.stories.tsx
+++ b/packages/components/src/components/textarea-input/textarea-input.playground.stories.tsx
@@ -65,7 +65,7 @@ export default meta;
 
 const Template: StoryFn<TextareaInputProps> = ({ ...args }) => <TextareaInput {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<TextareaInputProps> = Template.bind({});
 Playground.args = {
   id: 'playgroundTextareaInput',
   label: 'Playground TextareaInput',

--- a/packages/components/src/components/textarea-input/textarea-input.visual-tests.stories.tsx
+++ b/packages/components/src/components/textarea-input/textarea-input.visual-tests.stories.tsx
@@ -17,7 +17,7 @@ const Template: StoryFn<TextareaInputProps> = args => (
   />
 );
 
-export const ResponsiveSize = Template.bind({});
+export const ResponsiveSize: StoryFn<TextareaInputProps> = Template.bind({});
 ResponsiveSize.args = {
   size: {
     base: 'sm',

--- a/packages/components/src/components/time-picker-native/time-picker-native.playground.stories.tsx
+++ b/packages/components/src/components/time-picker-native/time-picker-native.playground.stories.tsx
@@ -85,7 +85,7 @@ export default meta;
 
 const Template: StoryFn<TimePickerNativeProps> = ({ ...args }) => <TimePickerNative {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<TimePickerNativeProps> = Template.bind({});
 Playground.args = {
   id: 'playgroundTimePickerNative',
   label: 'Playground TimePickerNative',

--- a/packages/components/src/components/time-picker/time-picker.playground.stories.tsx
+++ b/packages/components/src/components/time-picker/time-picker.playground.stories.tsx
@@ -85,7 +85,7 @@ export default meta;
 
 const Template: StoryFn<TimePickerProps> = ({ ...args }) => <TimePicker {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<TimePickerProps> = Template.bind({});
 Playground.args = {
   id: 'playgroundTimePicker',
   label: 'Playground TimePicker',

--- a/packages/components/src/components/toggle/toggle.playground.stories.tsx
+++ b/packages/components/src/components/toggle/toggle.playground.stories.tsx
@@ -46,7 +46,7 @@ export default meta;
 
 const Template: StoryFn<ToggleProps> = ({ ...args }) => <Toggle {...args} />;
 
-export const Playground = Template.bind({});
+export const Playground: StoryFn<ToggleProps> = Template.bind({});
 Playground.args = {
   id: 'togglePlayground',
   size: 'md',

--- a/packages/components/src/components/toggle/toggle.visual-tests.stories.tsx
+++ b/packages/components/src/components/toggle/toggle.visual-tests.stories.tsx
@@ -64,42 +64,42 @@ const Template: StoryFn<ToggleProps> = ({ ...args }) => (
   </Box>
 );
 
-export const AllSizes = Template.bind({});
+export const AllSizes: StoryFn<ToggleProps> = Template.bind({});
 AllSizes.args = { id: 'AllSizes' };
 
-export const AllSizesRequired = Template.bind({});
+export const AllSizesRequired: StoryFn<ToggleProps> = Template.bind({});
 AllSizesRequired.args = { id: 'AllSizesRequired', isRequired: true };
 
-export const AllSizesError = Template.bind({});
+export const AllSizesError: StoryFn<ToggleProps> = Template.bind({});
 AllSizesError.args = { id: 'AllSizesError', error: 'Agreement is required' };
 
-export const AllSizesDisabled = Template.bind({});
+export const AllSizesDisabled: StoryFn<ToggleProps> = Template.bind({});
 AllSizesDisabled.args = { id: 'AllSizesDisabled', isDisabled: true };
 
-export const AllSizesHideLabel = Template.bind({});
+export const AllSizesHideLabel: StoryFn<ToggleProps> = Template.bind({});
 AllSizesHideLabel.args = { id: 'AllSizesHideLabel', hideLabel: true };
 
-export const AllSizesHideLabelError = Template.bind({});
+export const AllSizesHideLabelError: StoryFn<ToggleProps> = Template.bind({});
 AllSizesHideLabelError.args = {
   id: 'AllSizesHideLabelError',
   hideLabel: true,
   error: 'Agreement is required',
 };
 
-export const AllSizesWithHelpText = Template.bind({});
+export const AllSizesWithHelpText: StoryFn<ToggleProps> = Template.bind({});
 AllSizesWithHelpText.args = {
   id: 'AllSizesWithHelpText',
   helpText: 'This is helpful text',
 };
 
-export const AllSizesWithHelpTextRequired = Template.bind({});
+export const AllSizesWithHelpTextRequired: StoryFn<ToggleProps> = Template.bind({});
 AllSizesWithHelpTextRequired.args = {
   id: 'AllSizesWithHelpTextRequired',
   helpText: 'This is helpful text',
   isRequired: true,
 };
 
-export const AllSizesWithHelpTextRequiredError = Template.bind({});
+export const AllSizesWithHelpTextRequiredError: StoryFn<ToggleProps> = Template.bind({});
 AllSizesWithHelpTextRequiredError.args = {
   id: 'AllSizesWithHelpTextRequired',
   helpText: 'This is helpful text',


### PR DESCRIPTION
Se corrigieron los tipos de los archivos de los componentes de rhino-ui, de manera que el compilador de typescript no dé errores y que se haga un build más limpio.
![image](https://github.com/rhinolabs/rhino-ui/assets/60011748/e82a8278-07b4-42d8-aab6-a2a30b979fa8)
